### PR TITLE
ci(macos): replaces .NET Core 3.1 in unit tests with .NET 7

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,8 +25,8 @@ env:
   DOTNET_NOLOGO: true
   dotnet-version: |
     8.0.x
+    7.0.x
     6.0.x
-    3.1.x
 
 jobs:
   analyze:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,8 +13,8 @@ env:
   DOTNET_NOLOGO: true
   dotnet-version: |
     8.0.x
+    7.0.x
     6.0.x
-    3.1.x
 
 jobs:
   determine-version:

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -14,8 +14,8 @@ env:
   DOTNET_NOLOGO: true
   dotnet-version: |
     8.0.x
+    7.0.x
     6.0.x
-    3.1.x
 
 jobs:
   # Blog https://iterative.ai/blog/testing-external-contributions-using-github-actions-secrets

--- a/test/IbanNet.Extensions.Bban.Tests/IbanNet.Extensions.Bban.Tests.csproj
+++ b/test/IbanNet.Extensions.Bban.Tests/IbanNet.Extensions.Bban.Tests.csproj
@@ -1,22 +1,23 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net6.0;netcoreapp3.1;net472;net462</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;net472;net462</TargetFrameworks>
 
     <IsTestProject>true</IsTestProject>
 
     <RootNamespace>IbanNet.Extensions.Bban</RootNamespace>
+    <LegacyNet Condition="'$(TargetFramework)'=='net472' Or '$(TargetFramework)'=='net462'">true</LegacyNet>
   </PropertyGroup>
 
-  <ItemGroup Condition="$(TargetFramework.StartsWith('netcoreapp')) Or '$(TargetFramework)'=='net8.0' Or '$(TargetFramework)'=='net6.0'">
+  <ItemGroup Condition="'$(LegacyNet)'!='true'">
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="IbanNet.DependencyInjection.ServiceProvider" Version="5.18.0" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\IbanNet.Extensions.Bban\IbanNet.Extensions.Bban.csproj" AdditionalProperties="TargetFramework=net8.0" Condition="'$(TargetFramework)'=='net8.0'" />
-    <ProjectReference Include="..\..\src\IbanNet.Extensions.Bban\IbanNet.Extensions.Bban.csproj" AdditionalProperties="TargetFramework=netstandard2.1" Condition="'$(TargetFramework)'=='net6.0'" />
-    <ProjectReference Include="..\..\src\IbanNet.Extensions.Bban\IbanNet.Extensions.Bban.csproj" AdditionalProperties="TargetFramework=netstandard2.0" Condition="'$(TargetFramework)'=='netcoreapp3.1'" />
+    <ProjectReference Include="..\..\src\IbanNet.Extensions.Bban\IbanNet.Extensions.Bban.csproj" AdditionalProperties="TargetFramework=netstandard2.1" Condition="'$(TargetFramework)'=='net7.0'" />
+    <ProjectReference Include="..\..\src\IbanNet.Extensions.Bban\IbanNet.Extensions.Bban.csproj" AdditionalProperties="TargetFramework=netstandard2.0" Condition="'$(TargetFramework)'=='net6.0'" />
     <ProjectReference Include="..\..\src\IbanNet.Extensions.Bban\IbanNet.Extensions.Bban.csproj" AdditionalProperties="TargetFramework=net472" Condition="'$(TargetFramework)'=='net472'" />
     <ProjectReference Include="..\..\src\IbanNet.Extensions.Bban\IbanNet.Extensions.Bban.csproj" AdditionalProperties="TargetFramework=net462" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>

--- a/test/IbanNet.Extensions.Bban.Tests/IbanNetOptionsBuilderTests.cs
+++ b/test/IbanNet.Extensions.Bban.Tests/IbanNetOptionsBuilderTests.cs
@@ -1,4 +1,4 @@
-﻿#if NETCOREAPP3_1_OR_GREATER
+﻿#if NETCOREAPP
 using System;
 using System.Linq;
 using FluentAssertions;


### PR DESCRIPTION
Due to `setup-dotnet` seemingly no longer supporting .NET Core 3.1 on macos image, replacing it with .NET 7.
This only affects tests. The `sonarcloud` merge requirement will fail since PR's run that job from `main` branch.
